### PR TITLE
Change plugin to accept "theme" and "layout_config" through telescope extensions setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,15 @@ telescope.setup {
           ["<C-k>"] = lga_actions.quote_prompt(),
         }
       }
+      -- ... also accepts theme settings, for example:
+      -- theme = 'dropdown', -- use dropdown theme
+      -- layout_config = { mirror=true }, -- mirror preview pane
     }
   }
 }
 ```
+
+This extension accepts the same options as `builtin.live_grep`, check out `:help live_grep` and `:help vimgrep_arguments` for more information. Additionally it also accepts `theme` and `layout_config`.
 
 
 ### Mapping recipes:

--- a/lua/telescope/_extensions/live_grep_args.lua
+++ b/lua/telescope/_extensions/live_grep_args.lua
@@ -51,6 +51,11 @@ local live_grep_args = function(opts)
     return cmd
   end
 
+  -- apply theme
+  if opts.theme then
+    opts = require('telescope.themes')['get_' .. opts.theme](opts)
+  end
+
   pickers.new(opts, {
     prompt_title = "Live Grep (Args)",
     finder = finders.new_job(cmd_generator, opts.entry_maker, opts.max_results, opts.cwd),


### PR DESCRIPTION
Change plugin to accept configuration through telescope extensions setup like:
```lua
local telescope = require 'telescope'
telescope.setup{
  extensions = {
    live_grep_raw = {
      vimgrep_arguments = {...},
      theme = 'dropdown',
      mappings = {i={...}, ...},
      ...
    }
  }
}
telescope.load_extension('live_grep_raw')
```
