### PR TITLE
Shortcut functions (for use in mappings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ keymap.set("n", "<leader>gc", live_grep_args_shortcuts.grep_word_under_cursor)
 
 Available shortcuts:
 
-| Name | Action |
-| --- | --- |
-| `grep_word_under_cursor` | Start live grep with word under cursor |
+| Name | Action | Options |
+| --- | --- | --- |
+| `grep_word_under_cursor` | Start live grep with word under cursor | <ul><li>`postfix`: postfix value to add; defaults to ` -F ` (Treat the pattern as a literal string)</li><li>`quote`: Whether to quote the value; defaults to true</li><li>`trim`: Whether to trim the value; defaults to true</li></ul> |
+| `grep_visual_selection` | Start live grep with visual selection | see `grep_word_under_cursor` |
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ This table provides some mapping ideas:
 | `actions.quote_prompt({ postfix = ' -t' })` | Quote prompt and add `-t` | `foo` → `"foo" -t` |
 
 
+### Shortcut functions
+
+Live grep args ships some additional shortcuts you can map.
+
+This is an example to live grep for the word under the cursor:
+
+```
+local live_grep_args_shortcuts = require("telescope-live-grep-args.shortcuts")
+keymap.set("n", "<leader>gc", live_grep_args_shortcuts.grep_word_under_cursor)
+```
+
+Available shortcuts:
+
+| Name | Action |
+| --- | --- |
+| `grep_word_under_cursor` | Start live grep with word under cursor |
+
+
 ## Development
 
 ### Running the tests

--- a/lua/telescope-live-grep-args/actions/quote_prompt.lua
+++ b/lua/telescope-live-grep-args/actions/quote_prompt.lua
@@ -3,6 +3,7 @@
 -- SPDX-License-Identifier: MIT
 
 local action_state = require "telescope.actions.state"
+local helpers = require "telescope-live-grep-args.helpers"
 
 local default_opts = {
   quote_char = '"',
@@ -20,8 +21,7 @@ return function (opts)
     if opts.trim then
       prompt = vim.trim(prompt)
     end
-    prompt = prompt:gsub(opts.quote_char, "\\" .. opts.quote_char)
-    prompt = opts.quote_char .. prompt .. opts.quote_char .. opts.postfix
+    prompt = helpers.quote(prompt, { quote_char =  opts.quote_char }) .. opts.postfix
     picker:set_prompt(prompt)
   end
 end

--- a/lua/telescope-live-grep-args/helpers.lua
+++ b/lua/telescope-live-grep-args/helpers.lua
@@ -1,0 +1,19 @@
+-- SPDX-FileCopyrightText: 2023 Michael Weimann <mail@michael-weimann.eu>
+--
+-- SPDX-License-Identifier: MIT
+
+local M = {}
+
+local quote_default_opts = {
+  quote_char = '"',
+}
+
+M.quote = function (value, opts)
+  opts = opts or {}
+  opts = vim.tbl_extend("force", quote_default_opts, opts)
+
+  local quoted = value:gsub(opts.quote_char, "\\" .. opts.quote_char)
+  return opts.quote_char .. quoted .. opts.quote_char
+end
+
+return M

--- a/lua/telescope-live-grep-args/shortcuts.lua
+++ b/lua/telescope-live-grep-args/shortcuts.lua
@@ -1,0 +1,9 @@
+local live_grep_raw = require("telescope").extensions.live_grep_args
+
+local M = {}
+
+M.grep_word_under_cursor = function ()
+  live_grep_raw.live_grep_raw({ default_text = vim.fn.expand("<cword>")})
+end
+
+return M

--- a/lua/telescope-live-grep-args/shortcuts.lua
+++ b/lua/telescope-live-grep-args/shortcuts.lua
@@ -17,7 +17,7 @@ local grep_under_default_opts = {
   trim = true,
 }
 
-local function proces_grep_under_text(value, opts)
+local function process_grep_under_text(value, opts)
   opts = opts or {}
   opts = vim.tbl_extend("force", grep_under_default_opts, opts)
 
@@ -41,14 +41,14 @@ local M = {}
 
 M.grep_word_under_cursor = function(opts)
   local word_under_cursor = vim.fn.expand("<cword>")
-  word_under_cursor = proces_grep_under_text(word_under_cursor, opts)
+  word_under_cursor = process_grep_under_text(word_under_cursor, opts)
   live_grep_args.live_grep_args({ default_text = word_under_cursor })
 end
 
 M.grep_visual_selection = function(opts)
   local visual = get_visual()
   local text = visual[1] or ""
-  text = proces_grep_under_text(text, opts)
+  text = process_grep_under_text(text, opts)
   live_grep_args.live_grep_args({ default_text = text })
 end
 

--- a/lua/telescope-live-grep-args/shortcuts.lua
+++ b/lua/telescope-live-grep-args/shortcuts.lua
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2023 Michael Weimann <mail@michael-weimann.eu>
+--
+-- SPDX-License-Identifier: MIT
+
 local live_grep_args = require("telescope").extensions.live_grep_args
 local helpers = require("telescope-live-grep-args.helpers")
 

--- a/lua/telescope-live-grep-args/shortcuts.lua
+++ b/lua/telescope-live-grep-args/shortcuts.lua
@@ -1,9 +1,51 @@
-local live_grep_raw = require("telescope").extensions.live_grep_args
+local live_grep_args = require("telescope").extensions.live_grep_args
+local helpers = require("telescope-live-grep-args.helpers")
+
+local function get_visual()
+  local _, ls, cs = unpack(vim.fn.getpos('v'))
+  local _, le, ce = unpack(vim.fn.getpos('.'))
+  return vim.api.nvim_buf_get_text(0, ls - 1, cs - 1, le - 1, ce, {})
+end
+
+local grep_under_default_opts = {
+  postfix = " -F ",
+  quote = true,
+  trim = true,
+}
+
+local function proces_grep_under_text(value, opts)
+  opts = opts or {}
+  opts = vim.tbl_extend("force", grep_under_default_opts, opts)
+
+  if opts.trim then
+    value = vim.trim(value)
+  end
+
+  if opts.quote then
+    value = helpers.quote(value, opts)
+  end
+
+  if opts.postfix then
+    value = value .. opts.postfix
+  end
+
+  return value
+end
 
 local M = {}
 
-M.grep_word_under_cursor = function ()
-  live_grep_raw.live_grep_raw({ default_text = vim.fn.expand("<cword>")})
+
+M.grep_word_under_cursor = function(opts)
+  local word_under_cursor = vim.fn.expand("<cword>")
+  word_under_cursor = proces_grep_under_text(word_under_cursor, opts)
+  live_grep_args.live_grep_args({ default_text = word_under_cursor })
+end
+
+M.grep_visual_selection = function(opts)
+  local visual = get_visual()
+  local text = visual[1] or ""
+  text = proces_grep_under_text(text, opts)
+  live_grep_args.live_grep_args({ default_text = text })
 end
 
 return M


### PR DESCRIPTION
Two shortcut functions as a start:

| Name | Action |
| --- | --- |
| `grep_word_under_cursor` | Start live grep with word under cursor |
| `grep_visual_selection` | Start live grep with visual selection |

Have a look at the README for details.

closes https://github.com/nvim-telescope/telescope-live-grep-args.nvim/issues/51

part of https://github.com/nvim-telescope/telescope-live-grep-args.nvim/issues/14