### PR TITLE
Fix nil warning when single quote

### DIFF
--- a/lua/telescope-live-grep-args/prompt_parser.lua
+++ b/lua/telescope-live-grep-args/prompt_parser.lua
@@ -122,8 +122,11 @@ M.parse = function(prompt, autoquote)
 
       if delim then
         frag = shift_until_delim(str, delim)
-        frag = string.gsub(frag, "\\\"", "\"")
-        frag = string.gsub(frag, "\\'", "'")
+        if frag then
+          frag = frag
+            :gsub( "\\\"", "\"")
+            :gsub("\\'", "'")
+        end
       else
         frag = shift_any(str)
       end

--- a/tests/specs/prompt_parser_spec.lua
+++ b/tests/specs/prompt_parser_spec.lua
@@ -6,6 +6,16 @@ local prompt_parser = require("telescope-live-grep-args.prompt_parser")
 
 local tests = {
   {
+    "\"",
+    {},
+    {}
+  },
+  {
+    "\"\"",
+    {""},
+    {""}
+  },
+  {
     "test1",     -- input value
     { "test1" }, -- expected with auto-quoting
     { "test1" }  -- expected without auto-quoting


### PR DESCRIPTION
If a single quote is entered, a warning is shown in the status bar. This adds an additional check and treats the empty quote as `nil`, meaning no actual search is performed until the next char is entered (this includes another quote - then the input is treat as an empty string).