### PR TITLE
add action to tokenize input

### DIFF
--- a/lua/telescope-live-grep-args/actions/init.lua
+++ b/lua/telescope-live-grep-args/actions/init.lua
@@ -3,5 +3,6 @@
 -- SPDX-License-Identifier: MIT
 
 return {
-  quote_prompt = require("telescope-live-grep-args.actions.quote_prompt"),
+	quote_prompt = require("telescope-live-grep-args.actions.quote_prompt"),
+	tokenize = require("telescope-live-grep-args.actions.tokenize"),
 }

--- a/lua/telescope-live-grep-args/actions/tokenize.lua
+++ b/lua/telescope-live-grep-args/actions/tokenize.lua
@@ -1,0 +1,23 @@
+local action_state = require("telescope.actions.state")
+
+local default_opts = {
+	quote_char = '"',
+	postfix = " ",
+	trim = true,
+}
+
+return function(opts)
+	opts = opts or {}
+	opts = vim.tbl_extend("force", default_opts, opts)
+
+	return function(prompt_bufnr)
+		local picker = action_state.get_current_picker(prompt_bufnr)
+		local prompt = picker:_get_prompt()
+		if opts.trim then
+			prompt = vim.trim(prompt)
+		end
+		prompt = prompt:gsub(opts.quote_char, "\\" .. opts.quote_char)
+		prompt = opts.quote_char .. prompt .. opts.quote_char .. opts.postfix
+		picker:set_prompt(prompt)
+	end
+end

--- a/lua/telescope-live-grep-args/actions/tokenize.lua
+++ b/lua/telescope-live-grep-args/actions/tokenize.lua
@@ -6,18 +6,56 @@ local default_opts = {
 	trim = true,
 }
 
+
 return function(opts)
 	opts = opts or {}
 	opts = vim.tbl_extend("force", default_opts, opts)
 
 	return function(prompt_bufnr)
+
+		local wrap, yield = coroutine.wrap, coroutine.yield
+
+		local function permgen(a, n)
+				n = n or #a
+				if n <= 1 then
+						yield(a)
+				else
+						for i = 1, n do
+								-- put i-th element as the last one
+								a[n], a[i] = a[i], a[n]
+								-- generate all permutations of the other elements
+								permgen(a, n - 1)
+								-- restore i-th element
+								a[n], a[i] = a[i], a[n]
+						end
+				end
+		end
+
+		function permutations(a)
+				-- call with coroutine.wrap()
+				return wrap(function() permgen(a) end)
+		end
+
 		local picker = action_state.get_current_picker(prompt_bufnr)
 		local prompt = picker:_get_prompt()
 		if opts.trim then
 			prompt = vim.trim(prompt)
 		end
-		prompt = prompt:gsub(opts.quote_char, "\\" .. opts.quote_char)
-		prompt = opts.quote_char .. prompt .. opts.quote_char .. opts.postfix
+		local tokens = {}
+		-- TODO interpret two spaces or more as a literal space
+		for token in prompt:gmatch("%S+") do
+			table.insert(tokens, token)
+		end
+
+		prompt = ""
+		-- TODO Remove duplicate permutations
+		-- a a b → a.*b.*a|b.*a.*a|b.*a.*a|a.*b.*a|a.*a.*b|a.*b.*a it should be:
+		-- a a b → a.*b.*a|b.*a.*a|a.*a.*b
+		for combo in permutations(tokens) do
+			prompt = prompt .. "|" .. table.concat(combo, '.*')
+		end
+		prompt = prompt:sub(2)
+
 		picker:set_prompt(prompt)
 	end
 end


### PR DESCRIPTION
The idea is to tokenize the input in live grep to allow for fuzzy-like search. For example `a b c` is turned into:

`b.*c.*a|c.*b.*a|c.*a.*b|a.*c.*b|b.*a.*c|a.*b.*c`

The prompt is split by spaces to build a regular expression with al the permutations of that token.

This is a draft, the code is working but I have a couple of things I want to finish:

1. Remove duplicate permutations
2. Interpret two spaces or more as a literal space

Any suggestions are welcome!