### PR TITLE
Fix get_visual argument order bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Fixed
+
+- Visual selection now also works when selecting backwards
+
 ## 1.0.0 - 2023-08-28
 
 ### Added

--- a/lua/telescope-live-grep-args/shortcuts.lua
+++ b/lua/telescope-live-grep-args/shortcuts.lua
@@ -8,6 +8,11 @@ local helpers = require("telescope-live-grep-args.helpers")
 local function get_visual()
   local _, ls, cs = unpack(vim.fn.getpos("v"))
   local _, le, ce = unpack(vim.fn.getpos("."))
+
+  -- nvim_buf_get_text requires start and end args be in correct order
+  ls, le = math.min(ls, le), math.max(ls, le)
+  cs, ce = math.min(cs, ce), math.max(cs, ce)
+
   return vim.api.nvim_buf_get_text(0, ls - 1, cs - 1, le - 1, ce, {})
 end
 


### PR DESCRIPTION
Ensure that the `start_row`, `start_col`, `end_row`, and `end_col` arguments to `nvim_buf_get_text` are passed in the correct order regardless of the direction of the visual selection.  Previously, if the end of the visual selection was before the start, `nvim_buf_get_text` would raise an error saying "start_col must be less than end_col".

Fixes issue #63 