### PR TITLE
Add configurable title to the picker

### DIFF
--- a/lua/telescope/_extensions/live_grep_args.lua
+++ b/lua/telescope/_extensions/live_grep_args.lua
@@ -63,7 +63,7 @@ local live_grep_args = function(opts)
 
   pickers
     .new(opts, {
-      prompt_title = "Live Grep (Args)",
+      prompt_title = opts.prompt_title or "Live Grep (Args)",
       finder = finders.new_job(cmd_generator, opts.entry_maker, opts.max_results, opts.cwd),
       previewer = conf.grep_previewer(opts),
       sorter = sorters.highlighter_only(opts),


### PR DESCRIPTION
# Description

Add configurable title to the picker to allow more flexibility and customization for the picker.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Simply pass in an opts object containing a `prompt_title` to the `live_grep_args()` function.

```lua
live_grep_args({
  prompt_title = "Desired title",
})
```

# Checklist:

- [ x ] My code follows the style guidelines of this project (stylua)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
