### PR TITLE
WIP: Escape dash in prompt to prevent using part of prompt as an option

### DIFF
--- a/lua/telescope-live-grep-args/prompt_parser.lua
+++ b/lua/telescope-live-grep-args/prompt_parser.lua
@@ -79,8 +79,20 @@ end
 local non_autoquote_chars = {
   ["'"] = true,
   ['"'] = true,
-  ["-"] = true,
+  -- ["-"] = true, -- idk why dash here listed with the same purpose as the quotes
 }
+
+-- Check for a dash at the beginning of the prompt and escape it.
+-- We need to escape dash at the beginning of the prompt because such dash will be interpreted as an option.
+local function escape_dash_in_prompt(prompt)
+  first_char = string.sub(prompt, 1, 1)
+  pos = string.find(prompt, "-")
+  if pos == 1 or (pos == 2 and non_autoquote_chars[first_char]) then
+    prompt = prompt:sub(1, pos - 1) .. "\\" .. prompt:sub(pos)
+  end
+
+  return prompt
+end
 
 --- Parses prompt shell like and returns a table containing the arguments
 --- If autoquote is true (default) and promt does not start with ', " or - then { prompt } will be returned.
@@ -89,6 +101,7 @@ M.parse = function(prompt, autoquote)
     return {}
   end
 
+  prompt = escape_dash_in_prompt(prompt)
   autoquote = autoquote or autoquote == nil
   local first_char = string.sub(prompt, 1, 1)
   if autoquote and non_autoquote_chars[first_char] == nil then


### PR DESCRIPTION
# Description

WIP, but it works 🤔
Looking forward to the author's review and comments.

Check for a dash at the beginning of the prompt and escape it.
We need to escape dash at the beginning of the prompt because such dash will be interpreted as an option in rg.

Fixes #54 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Search for phrases like: "--jobs 123", " --jobs 123", "here's -jobs 123", "'--jobs 123' --iglob *", "'here's --jobs 123' --iglob *", etc.

**Configuration**:
NVIM v0.10.0-dev-6074+gfbe40caa7-Homebrew
Build type: Release
LuaJIT 2.1.1703358377

MacOS 14.2.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (no need) I have made corresponding changes to the documentation (lua annotations)
