### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ telescope.setup {
         i = {
           ["<C-k>"] = lga_actions.quote_prompt(),
           ["<C-i>"] = lga_actions.quote_prompt({ postfix = " --iglob " }),
+          -- freeze the current list and start a fuzzy search in the frozen list
+          ["<C-space>"] = actions.to_fuzzy_refine,
         },
       },
       -- ... also accepts theme settings, for example:


### PR DESCRIPTION
live_grep supports c-space by default so it would make a lot of sense to add this to the readme
Related to #39 