### PR TITLE
Fix `nil` Assignment to `frag` causing errors in subsequent logic execution.

### DIFF
--- a/lua/telescope-live-grep-args/helpers.lua
+++ b/lua/telescope-live-grep-args/helpers.lua
@@ -16,4 +16,13 @@ M.quote = function(value, opts)
   return opts.quote_char .. quoted .. opts.quote_char
 end
 
+M.extract_quotes = function(input)
+  local match = input:match('"(.-)"')
+  if match then
+    return match
+  else
+    return input
+  end
+end
+
 return M

--- a/lua/telescope-live-grep-args/prompt_parser.lua
+++ b/lua/telescope-live-grep-args/prompt_parser.lua
@@ -133,6 +133,8 @@ M.parse = function(prompt, autoquote)
         frag = shift_any(str)
       end
 
+      frag = frag or ''
+      
       if current_arg == nil then
         current_arg = frag
       else

--- a/lua/telescope-live-grep-args/prompt_parser.lua
+++ b/lua/telescope-live-grep-args/prompt_parser.lua
@@ -134,7 +134,7 @@ M.parse = function(prompt, autoquote)
       end
 
       frag = frag or ''
-      
+
       if current_arg == nil then
         current_arg = frag
       else


### PR DESCRIPTION
This is a simple modification. The variable `frag` is occasionally set to nil, which disrupts the execution of subsequent logic, such as `current_arg .. frag`. When this issue occurs, a vexing error window appears. I earnestly hope this can be rectified. While this may not be the most optimal solution, there might be more effective alternatives. Regardless, I am more than willing to collaborate fully to support your efforts in resolving this matter.

closes #73