### PR TITLE
Allow to pass options to shortcuts / Add shortcuts to grep in current file only

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ Available shortcuts:
 | Name | Action | Options |
 | --- | --- | --- |
 | `grep_word_under_cursor` | Start live grep with word under cursor | <ul><li>`postfix`: postfix value to add; defaults to ` -F ` (Treat the pattern as a literal string)</li><li>`quote`: Whether to quote the value; defaults to true</li><li>`trim`: Whether to trim the value; defaults to true</li></ul> |
+| `grep_word_under_cursor_current_buffer` | Same as `grep_word_under_cursor` but for the file of the current buffer | |
 | `grep_visual_selection` | Start live grep with visual selection | see `grep_word_under_cursor` |
+| `grep_word_visual_selection_current_buffer` | Same as `grep_visual_selection` but for the file of the current buffer | |
 
 
 ## Development

--- a/lua/telescope-live-grep-args/shortcuts.lua
+++ b/lua/telescope-live-grep-args/shortcuts.lua
@@ -38,22 +38,40 @@ local function process_grep_under_text(value, opts)
     value = value .. opts.postfix
   end
 
-  return value
+  opts["default_text"] = value
+
+  return opts
 end
 
 local M = {}
 
 M.grep_word_under_cursor = function(opts)
+  opts = opts or {}
   local word_under_cursor = vim.fn.expand("<cword>")
-  word_under_cursor = process_grep_under_text(word_under_cursor, opts)
-  live_grep_args.live_grep_args({ default_text = word_under_cursor })
+  opts = process_grep_under_text(word_under_cursor, opts)
+  live_grep_args.live_grep_args(opts)
 end
 
 M.grep_visual_selection = function(opts)
+  opts = opts or {}
   local visual = get_visual()
   local text = visual[1] or ""
-  text = process_grep_under_text(text, opts)
-  live_grep_args.live_grep_args({ default_text = text })
+  opts = process_grep_under_text(text, opts)
+  live_grep_args.live_grep_args(opts)
+end
+
+M.grep_word_visual_selection_current_buffer = function(opts)
+  opts = opts or {}
+  local curr_path = vim.fn.expand("%")
+  opts["search_dirs"] = { curr_path }
+  M.grep_visual_selection(opts)
+end
+
+M.grep_word_under_cursor_current_buffer = function(opts)
+  opts = opts or {}
+  local curr_path = vim.fn.expand("%")
+  opts["search_dirs"] = { curr_path }
+  M.grep_word_under_cursor(opts)
 end
 
 return M


### PR DESCRIPTION
# Description

Make shortcuts can pass option too.
Add some example of  searching in current buffer using current work or visual selection 

Fixes # (issue)

## Type of change
- New feature (non-breaking change which adds functionality)




# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation (lua annotations)
