### PR TITLE
support additional_args argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `additional_args` support to `live_grep_args()`
+
 ## 1.1.0 - 2024-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ telescope.load_extension("live_grep_args")
 
 This extension accepts the same options as `builtin.live_grep`, check out `:help live_grep` and `:help vimgrep_arguments` for more information. Additionally it also accepts `theme` and `layout_config`.
 
+`live_grep_args` args
+
+| Name | Type | Description | Example |
+| --- | --- | --- | --- |
+| `additional_args` | `function|table` | additional arguments to be passed on. Can be fn(opts) -> tbl | `{ '-tmd' }` |
+
 
 ### Mapping recipes:
 

--- a/lua/telescope/_extensions/live_grep_args.lua
+++ b/lua/telescope/_extensions/live_grep_args.lua
@@ -32,6 +32,15 @@ local live_grep_args = function(opts)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_vimgrep(opts)
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd)
 
+  local additional_args = {}
+  if opts.additional_args ~= nil then
+    if type(opts.additional_args) == "function" then
+      additional_args = opts.additional_args(opts)
+    elseif type(opts.additional_args) == "table" then
+      additional_args = opts.additional_args
+    end
+  end
+
   if opts.search_dirs then
     for i, path in ipairs(opts.search_dirs) do
       opts.search_dirs[i] = vim.fn.expand(path)
@@ -43,7 +52,7 @@ local live_grep_args = function(opts)
       return nil
     end
 
-    local args = tbl_clone(opts.vimgrep_arguments)
+    local args = vim.tbl_flatten({ tbl_clone(opts.vimgrep_arguments), tbl_clone(additional_args) })
     local prompt_parts = prompt_parser.parse(prompt, opts.auto_quoting)
 
     local cmd = vim.tbl_flatten({ args, prompt_parts, opts.search_dirs })


### PR DESCRIPTION
# Description

## Support for `additional_args`
This plugin currently doesn't support searching within hidden files and directories. This makes it difficult to work with, say `.github/workflows/` directories and the like. Telescope's live_grep picker has a solution for this: [additional_args](https://github.com/nvim-telescope/telescope.nvim/blob/10b8a82b042caf50b78e619d92caf0910211973d/lua/telescope/builtin/init.lua#L55). I would like to bring this feature to the live-grep-args extension. This will allow us to pass `additional_args = { "--hidden" }` to this extension so that hidden files are included. We also get other benefits with the ability to pass other CLI flags.

In this change, `additional_args` will be either a function or a table, so that it matches the signature of Telescope's live_grep picker. The implementation is just a copy of the [one on live_grep](https://github.com/nvim-telescope/telescope.nvim/blob/10b8a82b042caf50b78e619d92caf0910211973d/lua/telescope/builtin/__files.lua#L127-L134)

## About `vimgrep_arguments`
Currently, my workaround is to use `vimgrep_arguments`. The problem with this is that `vimgrep_arguments` is not merged with the [default value](https://github.com/nvim-telescope/telescope.nvim/blob/10b8a82b042caf50b78e619d92caf0910211973d/lua/telescope/config.lua#L709); it sets the entire thing. This is also the case in the telescope picker. Hence I have to set to `vimgrep_arguments` the entire ripgrep CLI command. This solution is prone to breaking or becoming stale.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Cloned plenary.nvim and ran `make test`

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1703358377

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/opt/homebrew/Cellar/neovim/0.9.5/share/nvim"
```
* Operating system and version:
```
Darwin 22.5.0 Darwin Kernel Version 22.5.0: Thu Jun  8 22:22:20 PDT 2023; root:xnu-8796.121.3~7/RELEASE_ARM64_T6000 arm64
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
