### PR TITLE
fix: extra char when vim option 'selection' = exclusive

### DIFF
--- a/lua/telescope-live-grep-args/shortcuts.lua
+++ b/lua/telescope-live-grep-args/shortcuts.lua
@@ -6,14 +6,7 @@ local live_grep_args = require("telescope").extensions.live_grep_args
 local helpers = require("telescope-live-grep-args.helpers")
 
 local function get_visual()
-  local _, ls, cs = unpack(vim.fn.getpos("v"))
-  local _, le, ce = unpack(vim.fn.getpos("."))
-
-  -- nvim_buf_get_text requires start and end args be in correct order
-  ls, le = math.min(ls, le), math.max(ls, le)
-  cs, ce = math.min(cs, ce), math.max(cs, ce)
-
-  return vim.api.nvim_buf_get_text(0, ls - 1, cs - 1, le - 1, ce, {})
+  return vim.fn.getregion(vim.fn.getpos("v"), vim.fn.getpos("."))
 end
 
 local grep_under_default_opts = {


### PR DESCRIPTION
# Description

When `:set selection=exclusive`, the returned value from `get_visual()` will contain an  extra char.

Use `vim.fn.getregion` which follows vim option 'selection' to fix this issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

**Configuration**:
* Neovim version (nvim --version): v0.10.1
* Operating system and version:  Darwin Kernel Version 23.6.0

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
