### PR TITLE
Update lazy.nvim syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Find the full [ripgrep guide](https://github.com/BurntSushi/ripgrep/blob/master/
 Add `telescope-live-grep-args.nvim` as `telescope.nvim` dependency, e.g.:
 
 ```lua
-use {
+return {
   "nvim-telescope/telescope.nvim",
   dependencies = {
     { 


### PR DESCRIPTION
# Description

This is a quick readme update to correct the syntax used by lazy.nvim

Fixes # (issue)
N/A

## Type of change

- Documentation update

# How Has This Been Tested?

Installed via Lazy with current config in README with an error, correctly installed via the proposed changes in this PR

