### PR TITLE
feat: add support for 'file_encoding' option

### DIFF
--- a/lua/telescope/_extensions/live_grep_args.lua
+++ b/lua/telescope/_extensions/live_grep_args.lua
@@ -41,6 +41,10 @@ local live_grep_args = function(opts)
     end
   end
 
+  if opts.file_encoding then
+    additional_args[#additional_args + 1] = "--encoding=" .. opts.file_encoding
+  end
+
   if opts.search_dirs then
     for i, path in ipairs(opts.search_dirs) do
       opts.search_dirs[i] = vim.fn.expand(path)


### PR DESCRIPTION
Following telescope.builtin.live_grep().

NOTE: grep_previewer already uses this option.

# Description

Implements 'file_encoding' option like in telescope.builtin.live_grep().
Without this previewer converts and breaks encoding, so this is also a bug fix.
The option is documented in telescope.builtin.live_grep(), so I didn't touch README.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
echo КОТ > utf-8
echo КОТ | iconv -t cp866 > cp866
```
`telescope.extensions.live_grep_args.live_grep_args({file_encoding = "cp866"})` typing КОТ finds 'cp866'.
`telescope.extensions.live_grep_args.live_grep_args({})` typing КОТ finds 'utf-8'.

**Configuration**:
* Neovim version (nvim --version): v0.10.1
* Operating system and version: NixOS 24.05 + unstable

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
