### PR TITLE
Update README: to_fuzzy_refine is from telescope.actions, not lga_actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ telescope.setup {
           ["<C-k>"] = lga_actions.quote_prompt(),
           ["<C-i>"] = lga_actions.quote_prompt({ postfix = " --iglob " }),
           -- freeze the current list and start a fuzzy search in the frozen list
-          ["<C-space>"] = lga_actions.to_fuzzy_refine,
+          ["<C-space>"] = require('telescope.actions').to_fuzzy_refine,
         },
       },
       -- ... also accepts theme settings, for example:


### PR DESCRIPTION
# Description

The <C-space> mapping in the sample config does not seem to work, upon inspection, the to_fuzzy_refine should come from telescope.actions, instead of the lga_actions.

Fixes #91

## Type of change

Documentation update

# How Has This Been Tested?

Tested with my own setup.

**Configuration**:
* Neovim version (nvim --version): v0.10.1
* Operating system and version: Ubuntu 22.04

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
