### PR TITLE
refactor: replace `tbl_flatten` after 0.12 deprecation warning (#83)

### DIFF
--- a/lua/telescope/_extensions/live_grep_args.lua
+++ b/lua/telescope/_extensions/live_grep_args.lua
@@ -52,10 +52,10 @@ local live_grep_args = function(opts)
       return nil
     end
 
-    local args = vim.tbl_flatten({ tbl_clone(opts.vimgrep_arguments), tbl_clone(additional_args) })
+    local args = vim.iter({ tbl_clone(opts.vimgrep_arguments), tbl_clone(additional_args) }):flatten():totable()
     local prompt_parts = prompt_parser.parse(prompt, opts.auto_quoting)
 
-    local cmd = vim.tbl_flatten({ args, prompt_parts, opts.search_dirs })
+    local cmd = vim.iter({ args, prompt_parts, opts.search_dirs }):flatten():totable()
     return cmd
   end
 


### PR DESCRIPTION
# Description

Replace `tbl_flatten` after 0.12 deprecation warning.

Fixes #83 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Opened nvim and made a search

**Configuration**:
* Neovim version (nvim --version):

```
NVIM v0.12.0
Build type: Release
LuaJIT 2.1.1741730670
```

* Operating system and version: NixOS unstable / "86_64

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation (lua annotations)~
